### PR TITLE
Add getCardSize Implementation

### DIFF
--- a/auto-entities.js
+++ b/auto-entities.js
@@ -12,7 +12,11 @@ class AutoEntities extends cardTools.litElement() {
     this.card = cardTools.createCard(Object.assign({entities: this.entities}, config.card));
   }
 
-
+ getCardSize() {
+    if(this.card && typeof this.card.getCardSize === "function")
+      this.card.getCardSize();
+    return 1;
+ }
   match(pattern, str){
     if (typeof(str) === "string" && typeof(pattern) === "string") {
       if((pattern.startsWith('/') && pattern.endsWith('/')) || pattern.indexOf('*') !== -1) {


### PR DESCRIPTION
When using state-switch.js came across a problem when an auto-entities card was used.

Auto-entities provides no implementation of getCardSize, which state-switch uses in the logic of reporting the "biggest" entity across all states.

I thought that auto-entities reporting the inner card size was useful for other cases too.

think about it, If you prefer to alter state-switch implementation I undestand.

Thanks,

