### PR TITLE
add expand_group filter to recursive include entities of groups

### DIFF
--- a/auto-entities.js
+++ b/auto-entities.js
@@ -105,6 +105,11 @@ class AutoEntities extends cardTools.LitElement {
             )
               unmatched = true;
             break;
+          case "group_expand":
+            if(!this.is_in_group(hass, value, e.entity_id)
+            )
+              unmatched = true;
+            break;
           case "attributes":
             Object.keys(value).forEach((entityKey) => {
               const k = entityKey.split(" ")[0];
@@ -122,6 +127,15 @@ class AutoEntities extends cardTools.LitElement {
       if(!unmatched) retval.push(count);
     });
     return retval;
+  }
+
+  is_in_group(hass, group_entity_id, entity_id) {
+    return group_entity_id.startsWith("group.")
+      && hass.states[group_entity_id]
+      && hass.states[group_entity_id].attributes.entity_id
+      && ((!entity_id.startsWith("group.") && hass.states[group_entity_id].attributes.entity_id.includes(entity_id))
+      || (hass.states[group_entity_id].attributes.entity_id.some((g) => this.is_in_group(hass, g, entity_id)))
+      )
   }
 
   get_entities()


### PR DESCRIPTION
a new group_expand filter, which does list entities of a group recursive but without group's itself.
to be honest, I tested it only with include. But implemented it in a way, that in theory it should work for exclude too.