### PR TITLE
Fix cards not updating when card_param is used

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -169,7 +169,7 @@ class AutoEntities extends LitElement {
     if(!compare(ent, this._entities))
     {
       this._entities = ent;
-      this.cardConfig = {...this.cardConfig, entities: this._entities};
+      this.cardConfig = {...this.cardConfig, [this._config.card_param || "entities"]: this._entities};
       if(ent.length === 0 && this._config.show_empty === false) {
         this.style.display = "none";
         this.style.margin = "0";


### PR DESCRIPTION
`card_param` was not respected during an update, causing the update to never correctly happen.

I have tested this change both with and without a custom `card_param`, and everything still works for me.

Fixes #148.