### PR TITLE
Revising readme to fix a couple of items I found while trying out card

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ filter:
         device_class: motion
 sort:
   method: last_changed
+  reverse: true
   count: 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ filter:
 Or:
 
 ```yaml
-template: "{{states.light | selectattr('state', '==', 'on') | list}}"
+template: "{{states.light | selectattr('state', '==', 'on') | map(attribute='entity_id') | list}}"
 ```
 
 ---


### PR DESCRIPTION
In my experience, without using reverse: true, the sensors would show in ascending order so the oldest motion detections were shown first.