### PR TITLE
Fix IP sort typo

### DIFF
--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -148,7 +148,7 @@ export const sortSchema = [
       { name: "reverse", type: "boolean", label: "Reverse" },
       { name: "ignore_case", type: "boolean", label: "Ignore case" },
       { name: "numeric", type: "boolean", label: "Numeric sort" },
-      { name: "ip", type: "boolean", label: "IP address short" },
+      { name: "ip", type: "boolean", label: "IP address sort" },
     ],
   },
 ];


### PR DESCRIPTION
Fixing typo in label for 'IP address sort' from 'short' to 'sort'.