### PR TITLE
Update workaround for cards which show errors with no entities.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ window.queueMicrotask =
   window.queueMicrotask || ((handler) => window.setTimeout(handler, 1));
 
 const HIDDEN_TYPES = ["section", "divider"];
+const CARDS_NO_ENTITY_WORKAROUND = [ "logbook", "map", "history-graph", "statistics-graph" ];
 
 class AutoEntities extends LitElement {
   connectedWhileHidden = true;
@@ -164,57 +165,17 @@ class AutoEntities extends LitElement {
     const newType = this._cardConfig?.type !== this._config.card?.type;
     this._entities = entities;
     this._cardConfig = JSON.parse(JSON.stringify(this._config.card ?? {}));
+    const cardEntities = (entities.length > 0) ? 
+      entities : 
+      CARDS_NO_ENTITY_WORKAROUND.includes(this._cardConfig.type) ? [{ entity: "auto_entities.dummy" }] : [];
     const cardConfig = {
       type: "entities",
-      [this._config.card_param || "entities"]: entities,
+      [this._config.card_param || "entities"]: cardEntities,
       ...this._config.card,
     };
     if (!this.card || newType) {
       const helpers = await (window as any).loadCardHelpers();
-
-      // Replace console.error in order to catch errors from cards which don't like to be given an empty entities list
-      (console as any).oldError = (console as any).oldError || [];
-      const _consoleError = console.error;
-      (console as any).oldError.push(_consoleError);
-      console.error = (...args) => {
-        if (args.length === 3 && args[2].message) {
-          if (
-            args[2].message.startsWith?.("Entities") || // Logbook-card
-            args[2].message.startsWith?.("Either entities") || // Map card
-            args[2].message.endsWith?.("entity") // History-graph card
-          ) {
-            return;
-          }
-        }
-        _consoleError(...args);
-      };
-
-      try {
-        this.card = await helpers.createCardElement(cardConfig);
-
-        if (this.card.localName === "hui-error-card") {
-          const errorCard = this.card as HuiErrorCard;
-          await customElements.whenDefined("hui-error-card");
-          let ctr = 10;
-          while (!errorCard._config && ctr) {
-            await new Promise((resolve) => window.setTimeout(resolve, 100));
-            ctr--;
-          }
-          if (
-            errorCard._config?.error?.startsWith?.("Entities") ||
-            errorCard._config?.error?.startsWith?.("Either entities") ||
-            errorCard._config?.error?.endsWith?.("entity")
-          ) {
-            this.card = undefined;
-            this._entities = undefined;
-            this._cardConfig = undefined;
-            this._cardBuiltResolve?.();
-            return;
-          }
-        }
-      } finally {
-        console.error = (console as any).oldError.pop();
-      }
+      this.card = await helpers.createCardElement(cardConfig);
     } else {
       this.card.setConfig(cardConfig);
     }


### PR DESCRIPTION
Makes code much simpler. Tested with each card included in `CARDS_NO_ENTITY_WORKAROUND`. Will get those with issue to test.