### PR TITLE
Performance improvements

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -80,9 +80,9 @@ export const RULES: Record<
     ]);
 
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
-      const dev = devices.find((d) => d.id === ent.device_id);
+      const dev = devices[ent.device_id];
       if (!dev) return false;
       return match(dev.id) || match(dev.name_by_user) || match(dev.name);
     };
@@ -95,9 +95,9 @@ export const RULES: Record<
     ]);
 
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
-      const dev = devices.find((d) => d.id === ent.device_id);
+      const dev = devices[ent.device_id];
       if (!dev) return false;
       return match(dev.manufacturer);
     };
@@ -109,9 +109,9 @@ export const RULES: Record<
       getDevices(hass),
     ]);
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
-      const dev = devices.find((d) => d.id === ent.device_id);
+      const dev = devices[ent.device_id];
       if (!dev) return false;
       return match(dev.model);
     };
@@ -125,13 +125,13 @@ export const RULES: Record<
     ]);
 
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
-      let area = areas.find((a) => a.area_id === ent.area_id);
+      let area = areas[ent.area_id];
       if (area) return match(area.name) || match(area.area_id);
-      const dev = devices.find((d) => d.id === ent.device_id);
+      const dev = devices[ent.device_id];
       if (!dev) return false;
-      area = areas.find((a) => a.area_id === dev.area_id);
+      area = areas[dev.area_id];
       if (!area) return false;
       return match(area.name) || match(area.area_id);
     };
@@ -145,16 +145,16 @@ export const RULES: Record<
       getFloors(hass),
     ]);
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
-      let area = areas.find((a) => a.area_id === ent.area_id);
+      let area = areas[ent.area_id];
       if (!area) {
-        const dev = devices.find((d) => d.id === ent.device_id);
+        const dev = devices[ent.device_id];
         if (!dev) return false;
-        area = areas.find((a) => a.area_id === dev.area_id);
+        area = areas[dev.area_id];
       }
       if (!area) return false;
-      const floor = floors.find((f) => f.floor_id === area.floor_id);
+      const floor = floors[area.floor_id];
       if (!floor) return false;
       return match(floor.name) || match(floor.floor_id);
     };
@@ -168,16 +168,16 @@ export const RULES: Record<
       getFloors(hass),
     ]);
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
-      let area = areas.find((a) => a.area_id === ent.area_id);
+      let area = areas[ent.area_id];
       if (!area) {
-        const dev = devices.find((d) => d.id === ent.device_id);
+        const dev = devices[ent.device_id];
         if (!dev) return false;
-        area = areas.find((a) => a.area_id === dev.area_id);
+        area = areas[dev.area_id];
       }
       if (!area) return false;
-      const floor = floors.find((f) => f.floor_id === area.floor_id);
+      const floor = floors[area.floor_id];
       if (!floor) return false;
       return match(floor.level);
     };
@@ -189,7 +189,7 @@ export const RULES: Record<
     ]);
 
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
       return match(ent.entity_category);
     };
@@ -216,7 +216,7 @@ export const RULES: Record<
     ]);
 
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
       return match(ent.platform) || match(ent.config_entry_id);
     };
@@ -228,7 +228,7 @@ export const RULES: Record<
     ]);
 
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
       if (!ent) return false;
       return match(ent.hidden_by);
     };
@@ -243,18 +243,18 @@ export const RULES: Record<
 
     const match_label = (lbl) => {
       if (match(lbl)) return true;
-      const label = labels.find((l) => l.label_id === lbl);
+      const label = labels[lbl];
       return match(label?.name);
     };
 
     return (entity) => {
-      const ent = entities.find((e) => e.entity_id === entity.entity_id);
+      const ent = entities[entity.entity_id];
 
       if (!ent) return false;
       if (!ent.labels) return false;
       if (ent.labels.some(match_label)) return true;
 
-      const dev = devices.find((d) => d.id === ent.device_id);
+      const dev = devices[ent.device_id];
       if (!dev) return false;
       return dev.labels.some(match_label);
     };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -42,7 +42,7 @@ export function getFloors(hass) {
 }
 export function getDevices(hass) {
   cache.devices =
-    cache.devices ?? cacheByProperty(hass, "device", "config_id");
+    cache.devices ?? cacheByProperty(hass, "device", "id");
   return cache.devices;
 }
 export function getEntities(hass) {

--- a/src/process_entity.ts
+++ b/src/process_entity.ts
@@ -10,11 +10,11 @@ export const process_entity = async (hass: HassObject, entity, entity_id) => {
 
   const state = hass?.states?.[entity_id];
 
-  const ent = entities.find((e) => e.entity_id === entity_id);
-  const dev = ent ? devices.find((d) => d.id === ent.device_id) : undefined;
-  let area = ent ? areas.find((a) => a.area_id === ent.area_id) : undefined;
+  const ent = entities[entity_id];
+  const dev = ent ? devices[ent.device_id] : undefined;
+  let area = ent ? areas[ent.area_id] : undefined;
   if (area === undefined)
-    area = dev ? areas.find((a) => a.area_id === dev.area_id) : undefined;
+    area = dev ? areas[dev.area_id] : undefined;
 
   let str = JSON.stringify(entity);
   str = str.replace(/this.entity_id/g, entity_id);

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -60,9 +60,9 @@ const COMPARISONS: Record<
       getEntities(hass),
       getDevices(hass),
     ]);
-    const ent = entities.find((e) => e.entity_id === x.entity_id);
+    const ent = entities[x.entity_id];
     if (!ent) return undefined;
-    const dev = devices.find((d) => d.id === ent.device_id);
+    const dev = devices[ent.device_id];
     if (!dev) return undefined;
     return dev.name_by_user ?? dev.name;
   },
@@ -72,13 +72,13 @@ const COMPARISONS: Record<
       getDevices(hass),
       getAreas(hass),
     ]);
-    const ent = entities.find((e) => e.entity_id === x.entity_id);
+    const ent = entities[x.entity_id];
     if (!ent) return undefined;
-    let area = areas.find((a) => a.area_id === ent.area_id);
+    let area = areas[ent.area_id];
     if (area) return area.name;
-    const dev = devices.find((d) => d.id === ent.device_id);
+    const dev = devices[ent.device_id];
     if (!dev) return undefined;
-    area = areas.find((a) => a.area_id === dev.area_id);
+    area = areas[dev.area_id];
     if (!area) return undefined;
     return area.name;
   },


### PR DESCRIPTION
Cache hass registry lists by property id, then lookup cache directly rather than using Array.find(). This should give a performance improvement but will need testing to confirm. 

Will use recent issue reports for testing (#549, #557, #438)  