### PR TITLE
Split translated states to own filter 'state_translated'

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Each filter has a set of rules and will match entities which match **ALL** rules
 | --------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `domain`              | Entity domain                                                                               | `light`, `binary_sensor`, `media_player`             |
 | `state`               | Current state of entity.                                                                    | `"on"`, `home`, `"3.14"`, `"Triggered"`              |
+| `state_translated`       | Current state of entity as translated using Frontend language user setting. For numeric states always use `state` as translated numeric values will include formatting that will give unexpected results e.g. '3.14 s' => 3 | `Éteint`, `Maison`, `Déclenché`              |
 | `entity_id`           | Full entity id                                                                              | `light.bed_light`, `input_binary.weekdays_only`      |
 | `name`                | Friendly name attribute                                                                     | `Kitchen lights`, `Front door`                       |
 | `group`               | Entities in the group                                                                       | `group.living_room_lights`                           |

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -22,6 +22,7 @@ const ruleKeySelector = {
     ["device_model", "Model"],
     ["name", "Name"],
     ["state", "State"],
+    ["state_translated", "State Translated"],
   ],
 };
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -30,12 +30,11 @@ export const RULES: Record<
   },
   state: async (hass, value) => {
     const match = await matcher(value);
-    return (entity) => {
-      return (
-        match(entity.state) ||
-        match(hass.formatEntityState(hass.states[entity.entity_id]))
-      );
-    };
+    return (entity) => match(entity.state);
+  },
+  state_translated: async (hass, value) => {
+    const match = await matcher(value);
+    return (entity) => match(hass.formatEntityState(hass.states[entity.entity_id]));
   },
   name: async (hass, value) => {
     const match = await matcher(value);


### PR DESCRIPTION
Fixes #547 and #548. 

Too many edge cases to justify having `state` use translated states, hence the PR to split out to `state_translated`. For numeric, the translated state of '3000 px' may be '3,000 px'. `parseFloat()` will then return '3'. Also if a state is a datetime, then there may be cases to check, though in this case a different filter should be used.  