### PR TITLE
Load card/else via Hui card

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ class AutoEntities extends LitElement {
   @property() _config: AutoEntitiesConfig;
   @property() hass: any;
   @property() preview: boolean;
+  @property() layout: string;
   @property() card: HuiCard;
   @property() else?: HuiCard;
   @property() _template: string[];
@@ -159,6 +160,7 @@ class AutoEntities extends LitElement {
     this.else = document.createElement("hui-card") as HuiCard;
     this.else.hass = this.hass;
     this.else.preview = this.preview;
+    this.else.layout = this.layout;
     this.else.config = this._config.else;
     this.else.load();
   }
@@ -186,6 +188,7 @@ class AutoEntities extends LitElement {
       this.card = document.createElement("hui-card") as HuiCard;
       this.card.hass = this.hass;
       this.card.preview = this.preview;
+      this.card.layout = this.layout;
       this.card.config = cardConfig;
       this.card.load();
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { get_sorter } from "./sort";
 import {
   AutoEntitiesConfig,
   EntityList,
-  LovelaceCard,
+  HuiCard,
   LovelaceRowConfig,
 } from "./types";
 import pjson from "../package.json";
@@ -29,8 +29,8 @@ class AutoEntities extends LitElement {
   @property() _config: AutoEntitiesConfig;
   @property() hass: any;
   @property() preview: boolean;
-  @property() card: LovelaceCard;
-  @property() else?: LovelaceCard;
+  @property() card: HuiCard;
+  @property() else?: HuiCard;
   @property() _template: string[];
   @state() empty = false;
 
@@ -156,10 +156,11 @@ class AutoEntities extends LitElement {
 
   async build_else() {
     if (this._config.else === undefined) return;
-    const helpers = await (window as any).loadCardHelpers();
-    this.else = await helpers.createCardElement(this._config.else);
+    this.else = document.createElement("hui-card") as HuiCard;
     this.else.hass = this.hass;
     this.else.preview = this.preview;
+    this.else.config = this._config.else;
+    this.else.load();
   }
 
   async update_card(entities: EntityList) {
@@ -180,16 +181,19 @@ class AutoEntities extends LitElement {
       [this._config.card_param || "entities"]: cardEntities,
       ...this._config.card,
     };
+
     if (!this.card || newType) {
-      const helpers = await (window as any).loadCardHelpers();
-      this.card = await helpers.createCardElement(cardConfig);
+      this.card = document.createElement("hui-card") as HuiCard;
+      this.card.hass = this.hass;
+      this.card.preview = this.preview;
+      this.card.config = cardConfig;
+      this.card.load();
     } else {
-      this.card.setConfig(cardConfig);
+      this.card.config = cardConfig;
+      this.card.load();
     }
 
     this._cardBuiltResolve?.();
-    this.card.hass = this.hass;
-    this.card.preview = this.preview;
 
     this.empty =
       entities.length === 0 ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface LovelaceCard extends HTMLElement {
   hass: any;
   setConfig(config: any): void;
   getCardSize?(): number;
+  preview?: boolean;
 }
 export interface HuiErrorCard extends LovelaceCard {
   _config: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface LovelaceCard extends HTMLElement {
 export interface HuiCard extends LovelaceCard {
   load(): void;
   config?: any;
+  layout?: string;
   _element?: LovelaceCard;
 }
 export interface HuiErrorCard extends LovelaceCard {

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,11 @@ export interface LovelaceCard extends HTMLElement {
   getCardSize?(): number;
   preview?: boolean;
 }
+export interface HuiCard extends LovelaceCard {
+  load(): void;
+  config?: any;
+  _element?: LovelaceCard;
+}
 export interface HuiErrorCard extends LovelaceCard {
   _config: any;
 }


### PR DESCRIPTION
PR #583 (Preview) to be merged first as the branch for this PR is based off that branch.

This uses hui-card to load cards as this is best for modern Home Assistant and allows for stock visibility options to work correctly as well as hui-card based elements like grids etc to work directly with card-mod v4.

This may be breaking if users have say used card-mod to style from auto-entities root to generated card(s). Suggest this be a major point release with a beta period, after the other waiting PRs are released in a minor point release.

Added passing through layout to fix #470 