### PR TITLE
Use choose selector for filter pickers to allow for built in selector or custom

### DIFF
--- a/src/editor/auto-entities-filter-editor.ts
+++ b/src/editor/auto-entities-filter-editor.ts
@@ -6,9 +6,7 @@ import {
   rule_to_form,
   form_to_rule,
   nonFilterSchema,
-  postProcess,
   sortSchema,
-  hasSelector,
   templateSchema,
   entitiesSchema,
 } from "./schema";
@@ -148,12 +146,6 @@ class AutoEntitiesFilterEditor extends LitElement {
 
   updated(changedProperties) {
     this.updateComplete.then(async () => {
-      // Go through all selectors and force them to allow custom values
-      const promises = Array.from(
-        this.shadowRoot.querySelectorAll(".filter-rule-form")
-      ).map(postProcess);
-      await Promise.all(promises);
-
       // Populate forms with data AFTER selectors have been patched.
       // Otherwise they may overwrite the data with undefined
       this.shadowRoot.querySelectorAll("ha-form").forEach((form) => {
@@ -197,15 +189,6 @@ class AutoEntitiesFilterEditor extends LitElement {
                   </ha-button>
                   ${filter.type === undefined
                     ? html`
-                        ${hasSelector(filter)
-                          ? html`
-                              <p class="info">
-                                If entering a custom Value (e.g. "*light" or
-                                "/^[Bb]ed/") in a box with options, you need to
-                                finish with the Enter key.
-                              </p>
-                            `
-                          : ""}
                         <ha-form
                           .hass=${this.hass}
                           .schema=${filterSchema(filter)}

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -28,18 +28,68 @@ const ruleKeySelector = {
 
 const filterValueSelector = {
   attributes: { object: {} },
-  area: { area: {} },
-  device: { device: {} },
-  entity_id: { entity: {} },
-  floor: { floor: {} },
-  group: { entity: { filter: { domain: "group" } } },
-  integration: { config_entry: {} },
-  label: { label: {} },
+  area: { 
+    choose: {
+      choices: {
+        area: { selector: { area: {} } },
+        custom: { selector: { text: {} } }
+      }
+    } 
+  },
+  domain: { text: {} },
+  device: { 
+    choose: {
+      choices: {
+        device: { selector: { device: {} } },
+        custom: { selector: { text: {} } }
+      } 
+    }
+  },
+  entity_id: { 
+    choose: {
+      choices: {
+        entity: { selector: { entity: {} } },
+        custom: { selector: { text: {} } }
+      } 
+    }
+  },
+  floor: { 
+    choose: {
+      choices: {
+        floor: { selector: { floor: {} } },
+        custom: { selector: { text: {} } }
+      }
+    }
+  },
+  group: { 
+    choose: {
+      choices: {
+        entity: { selector: { entity: {} } },
+        custom: { selector: { text: {} } }
+      } 
+    }
+  },
+  integration: { 
+    choose: {
+      choices: {
+        integration: { selector: { config_entry: {} } },
+        custom: { selector: { text: {} } }
+      }
+    }
+  },
+  label: { 
+    choose: {
+      choices: {
+        label: { selector: { label: {} } },
+        custom: { selector: { text: {} } }
+      }
+    }
+  },
 };
 
-export const hasSelector = (filter) => {
-  return Object.keys(filter).some((k) => k in filterValueSelector);
-};
+export const isRuleKeySelector = (key) => {
+  return ruleKeySelector.options.some(([k, v]) => k === key);
+}
 
 const ruleSchema = ([key, value], idx) => {
   if (["sort", "optios"].includes(key)) {
@@ -69,51 +119,6 @@ const ruleSchema = ([key, value], idx) => {
       },
     ],
   };
-};
-
-export const postProcess = async (form: Element) => {
-  await await_element(form);
-  for (const grid of await selectTree(form, "$ ha-form-grid", true)) {
-    await await_element(grid);
-    const selector = await selectTree(
-      grid,
-      "$ ha-form:nth-child(2) $ ha-selector"
-    );
-    if (!selector) continue;
-    await await_element(selector);
-
-    let cb =
-      (await selectTree(
-        selector,
-        "$ ha-selector-area $ ha-area-picker $ ha-combo-box"
-      )) ??
-      (await selectTree(
-        selector,
-        "$ ha-selector-device $ ha-device-picker $ ha-combo-box"
-      )) ??
-      (await selectTree(
-        selector,
-        "$ ha-selector-entity $ ha-entity-picker $ ha-combo-box"
-      )) ??
-      (await selectTree(
-        selector,
-        "$ ha-selector-label $ ha-label-picker $ ha-combo-box"
-      )) ??
-      (await selectTree(
-        selector,
-        "$ ha-selector-config_entry $ ha-config-entry-picker $ ha-combo-box"
-      )) ??
-      (await selectTree(
-        selector,
-        "$ ha-selector-floor $ ha-floor-picker $ ha-combo-box"
-      ));
-
-    if (cb) {
-      await await_element(cb);
-      cb.allowCustomValue = true;
-      continue;
-    }
-  }
 };
 
 export const filterSchema = (group) => {

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -114,7 +114,7 @@ const filterChooseValidators = {
     choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
   },
   integration: {  
-    validator: async (hass, value) => { return getConfigEntries(hass, "type", ["device", "hub", "service" ]).then((entries) => { return value in entries; }).catch(() => { return false; }); },
+    validator: async (hass, value) => { return getConfigEntries(hass, "type_filter", ["device", "hub", "service" ]).then((entries) => { return value in entries; }).catch(() => { return false; }); },
     choose_valid: (value) => { return { integration: value, active_choice: "integration" }; },
     choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
   },

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -144,6 +144,7 @@ const ruleSchema = ([key, value], idx) => {
   return {
     type: "grid",
     name: "",
+    column_min_width: filterValueSelector[key] !== undefined ? "100%" : undefined,
     schema: [
       {
         ...ruleKeySelector,
@@ -182,6 +183,7 @@ export const migrate_custom_rule_values = async (hass, config, types, callback) 
   const promises = [];
   
   Object.values(Array.isArray(types) ? types : [types]).forEach((type) => {
+    if (!config?.filter?.[type]) return;
     Object.values(config?.filter?.[type]).forEach((group, idx) => {
       const filters = { ...group as Object };
       Object.entries(filters).forEach(([key, value]) => {

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -1,4 +1,4 @@
-import { await_element, selectTree } from "../helpers/selecttree";
+import { getAreas, getConfigEntries, getDevices, getEntities, getFloors, getLabels } from "../helpers";
 
 const ruleKeySelector = {
   type: "select",
@@ -64,7 +64,7 @@ const filterValueSelector = {
   group: { 
     choose: {
       choices: {
-        entity: { selector: { entity: {} } },
+        group: { selector: { entity: {} } },
         custom: { selector: { text: {} } }
       } 
     }
@@ -86,6 +86,44 @@ const filterValueSelector = {
     }
   },
 };
+
+const filterChooseValidators = {
+  entity_id: {
+    validator: async (hass, value) => { return getEntities(hass).then((entities) => { return value in entities; }).catch(() => { return false; }); },
+    choose_valid: (value) => { return { entity: value, active_choice: "entity" }; },
+    choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
+  },
+  device: {
+    validator: async (hass, value) => { return getDevices(hass).then((devices) => { return value in devices; }).catch(() => { return false; }); },
+    choose_valid: (value) => { return { device: value, active_choice: "device" }; },
+    choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
+  },
+  area: {
+    validator: async (hass, value) => { return getAreas(hass).then((areas) => { return value in areas; }).catch(() => { return false; }); },
+    choose_valid: (value) => { return { area: value, active_choice: "area" }; },
+    choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
+  },
+  floor: {
+    validator: async (hass, value) => { return getFloors(hass).then((floors) => { return value in floors; }).catch(() => { return false; }); },
+    choose_valid: (value) => { return { floor: value, active_choice: "floor" }; },
+    choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
+  },
+  group: {
+    validator: async (hass, value) => { return getEntities(hass).then((entities) => { return value in entities; }).catch(() => { return false; }); },
+    choose_valid: (value) => { return { group: value, active_choice: "group" }; },
+    choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
+  },
+  integration: {  
+    validator: async (hass, value) => { return getConfigEntries(hass, "type", ["device", "hub", "service" ]).then((entries) => { return value in entries; }).catch(() => { return false; }); },
+    choose_valid: (value) => { return { integration: value, active_choice: "integration" }; },
+    choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
+  },
+  label: {
+    validator: async (hass, value) => { return getLabels(hass).then((labels) => { return value in labels; }).catch(() => { return false; }); },
+    choose_valid: (value) => { return { label: value, active_choice: "label" }; },
+    choose_custom: (value) => { return { custom: value, active_choice: "custom" }; },
+  }
+}
 
 export const isRuleKeySelector = (key) => {
   return ruleKeySelector.options.some(([k, v]) => k === key);
@@ -137,6 +175,34 @@ export const filterSchema = (group) => {
       selector: { object: {} },
     },
   ];
+};
+
+export const migrate_custom_rule_values = async (hass, config, types, callback) => {
+  const migrations = [];
+  const promises = [];
+  
+  Object.values(Array.isArray(types) ? types : [types]).forEach((type) => {
+    Object.values(config?.filter?.[type]).forEach((group, idx) => {
+      const filters = { ...group as Object };
+      Object.entries(filters).forEach(([key, value]) => {
+        if (key in filterChooseValidators && typeof value === "string") {
+          const promise = filterChooseValidators[key].validator(hass, value).then((is_valid) => {
+            if (is_valid) {
+              const new_value = filterChooseValidators[key].choose_valid(value);
+              migrations.push({new_value, idx, type, key});
+            } else {
+              const new_value = filterChooseValidators[key].choose_custom(value);
+              migrations.push({new_value, idx, type, key});
+            }
+          });
+          promises.push(promise);
+        }
+      });
+    });
+  });
+  
+  await Promise.all(promises);
+  callback(migrations);
 };
 
 export const rule_to_form = (group) => {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -41,7 +41,8 @@ export const RULES: Record<
     return (entity) => match(entity.attributes?.friendly_name);
   },
   group: async (hass, value) => (entity) => {
-    return hass.states[value]?.attributes?.entity_id?.includes(
+    const group = (typeof value === "object" && value.active_choice) ? value[value.active_choice] : value;
+    return hass.states[group]?.attributes?.entity_id?.includes(
       entity.entity_id
     );
   },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -92,7 +92,11 @@ function cacheConfigEntries<T>(
   filter_type?: string,
   filter_value?: any,
 ): Promise<Record<string, T>> {
-  return hass.callWS({ type: `config_entries/get` }).then((items: T[]) => {
+  const params: any = {};
+  if (filter_type !== undefined) {
+    params[filter_type] = filter_value;
+  }
+  return hass.callWS({ type: `config_entries/get`, ...params }).then((items: T[]) => {
     return items.reduce((acc, item) => {
       const key = item[property];
       if (typeof key === "string" || typeof key === "number") {

--- a/src/match.ts
+++ b/src/match.ts
@@ -5,7 +5,7 @@ export async function matcher(pattern: any): Promise<(value: any) => boolean> {
   const matchers = [];
   const transforms = [];
 
-  if (typeof pattern === "object" && pattern.active_choice) {
+  if (typeof pattern === "object" && pattern?.active_choice) {
     // Handle config from choose selector
     pattern = pattern[pattern.active_choice];
   }

--- a/src/match.ts
+++ b/src/match.ts
@@ -5,6 +5,11 @@ export async function matcher(pattern: any): Promise<(value: any) => boolean> {
   const matchers = [];
   const transforms = [];
 
+  if (typeof pattern === "object" && pattern.active_choice) {
+    // Handle config from choose selector
+    pattern = pattern[pattern.active_choice];
+  }
+
   if (typeof pattern === "string") {
     if (pattern.startsWith("$$")) {
       pattern = pattern.substring(2);


### PR DESCRIPTION
HA 2026.1 removes ha-combo-box for ha-generic-picker. Also entity picker does not handle custom values at all so moving to check for ha-generic-picker and set allowCustomValues will not work 100%. Good news is that 2026.1 also includes a new 'choose' selector which allows for users to choose between different selectors.

I have found one issue with the choose selector that hopefully witll get fixed fbefore 2026.1 release. See https://github.com/home-assistant/frontend/issues/28749