### PR TITLE
feat: add device_label filter and GUI editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Each filter has a set of rules and will match entities which match **ALL** rules
 | `level`               | Entities on a given level.                                                                  | `2`, `>1`                                            |
 | `device`              | Entities belonging to a Device                                                              | `Thomas iPhone`                                      |
 | `label`               | Entities that are tagged with a certain label                                               | `Show on dashboard`, `Holiday light`                 |
+| `device_label`        | Entities belonging to a device with a certain label                                         | `Show on dashboard`, `Holiday light`                 |
 | `device_manufacturer` | Entities belonging to a device by a given manufacturer                                      | `IKEA`                                               |
 | `device_model`        | Entities belonging to a device of a given model                                             | `Hue white ambiance E26/E27 (8718696548738)`         |
 | `integration`         | Entities included by a given integration. This is not possible for _all_ integrations.      | `plex`, `input_boolean`, `xiaomi_miio`, `mobile_app` |
@@ -339,6 +340,7 @@ card:
 filter:
   include:
     - device: /iPhone/
+    - device_label: "Personal Device"
 ```
 
 List the five last triggered motion sensors:

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -6,6 +6,7 @@ const ruleKeySelector = {
     ["area", "Area"],
     ["attributes", "Attribute"],
     ["device", "Device"],
+    ["device_label", "Device Label"],
     ["domain", "Domain"],
     ["entity_category", "Entity Category"],
     ["entity_id", "Entity ID"],
@@ -35,6 +36,7 @@ const filterValueSelector = {
   group: { entity: { filter: { domain: "group" } } },
   integration: { config_entry: {} },
   label: { label: {} },
+  device_label: { label: {} },
 };
 
 export const hasSelector = (filter) => {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -233,6 +233,26 @@ export const RULES: Record<
     };
   },
   label: async (hass, value) => {
+    const [match, entities, labels] = await Promise.all([
+      matcher(value),
+      getEntities(hass),
+      getLabels(hass),
+    ]);
+
+    const match_label = (lbl) => {
+      if (match(lbl)) return true;
+      const label = labels[lbl];
+      return match(label?.name);
+    };
+
+    return (entity) => {
+      const ent = entities[entity.entity_id];
+
+      if (!ent) return false;
+      return ent.labels?.some(match_label);
+    };
+  },
+  device_label: async (hass, value) => {
     const [match, entities, devices, labels] = await Promise.all([
       matcher(value),
       getEntities(hass),
@@ -250,12 +270,9 @@ export const RULES: Record<
       const ent = entities[entity.entity_id];
 
       if (!ent) return false;
-      if (!ent.labels) return false;
-      if (ent.labels.some(match_label)) return true;
-
       const dev = devices[ent.device_id];
       if (!dev) return false;
-      return dev.labels.some(match_label);
+      return dev.labels?.some(match_label);
     };
   },
 };

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -249,7 +249,11 @@ export const RULES: Record<
       const ent = entities[entity.entity_id];
 
       if (!ent) return false;
-      return ent.labels?.some(match_label);
+      if (ent.labels?.some(match_label)) return true;
+
+      const dev = devices[ent.device_id];
+      if (!dev) return false;
+      return dev.labels?.some(match_label);
     };
   },
   device_label: async (hass, value) => {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -247,13 +247,8 @@ export const RULES: Record<
 
     return (entity) => {
       const ent = entities[entity.entity_id];
-
       if (!ent) return false;
-      if (ent.labels?.some(match_label)) return true;
-
-      const dev = devices[ent.device_id];
-      if (!dev) return false;
-      return dev.labels?.some(match_label);
+      return ent.labels?.some(match_label);
     };
   },
   device_label: async (hass, value) => {
@@ -272,7 +267,6 @@ export const RULES: Record<
 
     return (entity) => {
       const ent = entities[entity.entity_id];
-
       if (!ent) return false;
       const dev = devices[ent.device_id];
       if (!dev) return false;
@@ -292,16 +286,24 @@ export async function get_filter(
         return RULES[rule]?.(hass, value) ?? (() => false);
       })
     )
-  )
-    .filter((r) => r !== undefined)
-    .filter(Boolean);
+  ).filter(Boolean);
 
-  return (entity: string | LovelaceRowConfig) => {
-    if (!rules.length) return false;
-    if (typeof entity !== "string") entity = entity.entity;
-    if (!entity) return false;
-    const hass_entity = hass?.states?.[entity];
-    if (!hass_entity) return false;
-    return rules.every((x) => x(hass_entity));
+  return (entity_id: string | LovelaceRowConfig) => {
+    let entity: HAState;
+    if (typeof entity_id === "string") {
+      entity = hass.states[entity_id];
+      if (!entity) entity = { entity_id, state: "unknown", last_changed: 0, last_updated: 0 };
+    } else {
+      entity = hass.states[entity_id.entity];
+      if (!entity)
+        entity = {
+          entity_id: entity_id.entity,
+          state: "unknown",
+          last_changed: 0,
+          last_updated: 0,
+        };
+    }
+
+    return rules.every((rule) => rule(entity));
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ interface FilterConfig {
   device?: string;
   device_manufacturer?: string;
   device_model?: string;
+  device_label?: string;
 
   attributes?: Record<string, string>;
 


### PR DESCRIPTION
- Implement device_label rule to match labels on the device an entity belongs to
- Separate label rule to only match labels on the entity itself
- Add device_label to GUI editor schema and type definitions
- Update README with documentation and usage example